### PR TITLE
Remove tracked log and ignore runtime logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .tmp.driveupload/
 node_modules/
+nesting_run.log
+nesting_timing.log
 


### PR DESCRIPTION
## Summary
- stop tracking `nesting_run.log`
- ignore the runtime log files

## Testing
- `git ls-files | grep log`

------
https://chatgpt.com/codex/tasks/task_e_6845dce5b1f48331a738cb619e5f6463